### PR TITLE
gmirr.sh: enhance the usage message

### DIFF
--- a/gnome/gmirr.sh
+++ b/gnome/gmirr.sh
@@ -69,11 +69,11 @@ while getopts 'd:l:f' OPTION
 	;;
 	  f)	VERSIONS=("${OLDVERSIONS[@]}" "$DEVVERSION")
 			;;
-	  ?)		echo "Usage: gmirr.sh -f -l LANG -d DIR"
+	  ?)		echo "Usage: gmirr.sh [-f] [-l LANG] [-d DIR]"
 			echo "Download all po/pot files from l10n.gnome.org"
-			echo "DIR: the target directory of the download, default: ~/gnome-translations"
-			echo "LANG: the code of the language. The default is taken from \$LANG"
-			echo "-f: Use this if you want to download old releases too (3.0 - 3.LASTRELEASE)"
+			echo " -d DIR   the target directory of the download (default: $TARGET)"
+			echo " -l LANG  specifies language code to use (default: use \$LANG)"
+			echo " -f       also download all old releases from 3.0 until latest available"
 			exit 2
 			;;
 	  esac


### PR DESCRIPTION
This is a suggestion of small enhance. It...:
- Adds square brackets to the main usage line to emphasise the optional arguments
- Put the whole optional argument on each line and veritcally aligns the their respective description
- Changes hard coded target "~/gnome-translations" to the variable TARGET, which set it as default